### PR TITLE
chore(tools): Add nano

### DIFF
--- a/docker/Dockerfile.php.template
+++ b/docker/Dockerfile.php.template
@@ -30,7 +30,7 @@ RUN install-php-extensions \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
+    git curl vim nano sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit

--- a/docker/Dockerfile.php71
+++ b/docker/Dockerfile.php71
@@ -30,7 +30,7 @@ RUN install-php-extensions \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
+    git curl vim nano sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit

--- a/docker/Dockerfile.php72
+++ b/docker/Dockerfile.php72
@@ -30,7 +30,7 @@ RUN install-php-extensions \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
+    git curl vim nano sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit

--- a/docker/Dockerfile.php73
+++ b/docker/Dockerfile.php73
@@ -30,7 +30,7 @@ RUN install-php-extensions \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
+    git curl vim nano sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit

--- a/docker/Dockerfile.php74
+++ b/docker/Dockerfile.php74
@@ -30,7 +30,7 @@ RUN install-php-extensions \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
+    git curl vim nano sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit

--- a/docker/Dockerfile.php80
+++ b/docker/Dockerfile.php80
@@ -30,7 +30,7 @@ RUN install-php-extensions \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
+    git curl vim nano sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit

--- a/docker/Dockerfile.php81
+++ b/docker/Dockerfile.php81
@@ -30,7 +30,7 @@ RUN install-php-extensions \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
+    git curl vim nano sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit

--- a/docker/php82/Dockerfile
+++ b/docker/php82/Dockerfile
@@ -30,7 +30,7 @@ RUN install-php-extensions \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
+    git curl vim nano sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit

--- a/docker/php83/Dockerfile
+++ b/docker/php83/Dockerfile
@@ -11,8 +11,7 @@ RUN install-php-extensions \
     exif \
     gd \
     gmp \
-    # waiting for https://github.com/mlocati/docker-php-extension-installer/pull/811
-    # imagick \
+    imagick \
     intl \
     ldap \
     memcached \
@@ -31,7 +30,7 @@ RUN install-php-extensions \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
+    git curl vim nano sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync mariadb-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit


### PR DESCRIPTION
While testing something inside the container, it became clear that some developers prefer nano over vim. I think we should include it in the base image already.

I noticed that applying the template removed the imagick comment, but I also see that https://github.com/mlocati/docker-php-extension-installer/pull/811 was merged in the meantime. Let's see what CI says? 
If you prefer, we can split it in a different commit, of course.