### PR TITLE
Make DCC variable a local one

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 function get_docker_compose_command() {
+    local DCC
     docker-compose version >/dev/null 2>/dev/null && DCC='docker-compose'
     docker compose version >/dev/null 2>/dev/null && DCC='docker compose'
     if [ -z "$DCC" ]; then
@@ -10,7 +11,7 @@ function get_docker_compose_command() {
 }
 
 function docker_compose() {
-    DCC=$(get_docker_compose_command)
+    local DCC=$(get_docker_compose_command)
     if [ -z "$DCC" ]; then
         echo "❌ Install docker-compose before running this script"
         exit 1


### PR DESCRIPTION
This is just a minor fix to avoid leaking of (temporary) variables out of function calls.