### PR TITLE
chore: Add ephemeral nextcloud-test container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,6 +155,29 @@ services:
     extra_hosts:
       - host.docker.internal:host-gateway
 
+  nextcloud-test:
+    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-81}:latest
+    environment:
+      SQL: sqlite
+      VIRTUAL_HOST: "nextcloud-test${DOMAIN_SUFFIX}"
+      PHP_XDEBUG_MODE: ${PHP_XDEBUG_MODE:-develop}
+    volumes:
+      - '${REPO_PATH_SERVER}:/var/www/html'
+      - '${REPO_PATH_SERVER}/apps-extra:/var/www/html/apps-extra'
+      - '${ADDITIONAL_APPS_PATH:-./data/apps-extra}:/var/www/html/apps-shared'
+      - /var/www/html/data
+      - /var/www/html/config
+      - /var/www/html/apps-writable
+      - ./data/skeleton/:/skeleton
+      - ./data/additional.config.php:/var/www/html/config/additional.config.php:ro
+      - ./data/shared:/shared
+    depends_on:
+      - redis
+      - mail
+      - ${PROXY_SERVICE:-proxy}
+    extra_hosts:
+      - host.docker.internal:host-gateway
+
   stable16:
     image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-73}:latest
     environment:
@@ -1020,6 +1043,7 @@ services:
     #  - '${STABLE_ROOT_PATH}/lookupserver:/var/www/html'
     extra_hosts:
       - host.docker.internal:host-gateway
+
   tinyproxy:
     image: docker.io/kalaksi/tinyproxy
     cap_drop:
@@ -1043,7 +1067,6 @@ services:
       interval: 5m
       timeout: 10s
       retries: 1
-
 
   previews_hpb:
     image: nextcloud/aio-imaginary:latest


### PR DESCRIPTION
I sometimes need an ephemeral container to run integration tests, so I don't want to have a persistent database or data. Therefore I suggest to add a "nextcloud-test" service, that does not use named volumes for config/data and also is forced to sqlite.
I am up for other/better ideas of course :) 