### PR TITLE
fix: adds the possibility of using rootless Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "${IP_BIND:-127.0.0.1}:${PROXY_PORT_HTTP:-80}:80"
       - "${IP_BIND:-127.0.0.1}:${PROXY_PORT_HTTPS:-443}:443"
     volumes:
-      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ${DOCKER_SOCKET-/var/run/docker.sock}:/tmp/docker.sock:ro
       - ./data/ssl/:/etc/nginx/certs
       - ./data/nginx/vhost.d/:/etc/nginx/vhost.d
     environment:
@@ -1087,7 +1087,7 @@ services:
     container_name: nextcloud-appapi-dsp-http
     network_mode: ${NETWORK_MODE:-master_default}
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_SOCKET-/var/run/docker.sock}:/var/run/docker.sock
     environment:
       - NC_HAPROXY_PASSWORD=${NC_HAPROXY_PASSWORD:-some_secure_password}
       - BIND_ADDRESS=${BIND_ADDRESS:-}
@@ -1103,7 +1103,7 @@ services:
     container_name: nextcloud-appapi-dsp-https
     network_mode: ${NETWORK_MODE:-host}
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_SOCKET-/var/run/docker.sock}:/var/run/docker.sock
       - ${CERT_PATH:-./data/ssl/app_api/app_api.pem}:/certs/cert.pem
     environment:
       - NC_HAPROXY_PASSWORD=${NC_HAPROXY_PASSWORD:-some_secure_password}

--- a/example.env
+++ b/example.env
@@ -53,6 +53,10 @@ SQL=mysql
 # the entries none, develop, debug, trace, and profile.
 PHP_XDEBUG_MODE=develop
 
+# Docker socket location, use it when you run rootless Docker
+# Replace "1000" with the uid used by your Docker engine (default $(id -u))
+# DOCKER_SOCKET=/run/user/1000/docker.sock
+
 # Nextcloud AppAPI Docker Socket Proxy
 # ------------------------------------
 # NC_HAPROXY_PASSWORD=some_secure_password


### PR DESCRIPTION
Hardcoding the doker.sock path prevents people from using Docker in rootless mode. Even when symlinking the user's docker.sock into /var/run/docker.sock does not work, as Docker does not follow the symlink and mounts a directory instead.

This patch allows to define an environment variable `DOCKER_SOCKET` to override the default value.